### PR TITLE
Add CI: fish syntax and indent checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install fish shell
+        uses: fish-shop/install-fish-shell@3d3495a8edde019283ece78087c4da133d03dd57 # v2.1.16
+
+      - name: Syntax check
+        uses: fish-shop/syntax-check@f74533521a177bc1047ea185e97dce5e89a643bd # v2.2.105
+
+      - name: Indent check
+        uses: fish-shop/indent-check@db90fa808dfeb434620e553dec75ba0967a557e8 # v2.2.107

--- a/completions/wd.fish
+++ b/completions/wd.fish
@@ -2,16 +2,16 @@
 complete -f -c wd
 
 # complete points
-complete -f -c wd -k -n "_wd_should_complete_point" -a "(_wd_complete_point)"
+complete -f -c wd -k -n _wd_should_complete_point -a "(_wd_complete_point)"
 
 # complete sub commands
-complete -f -c wd -k -n "_wd_complete_empty" -a help -d "show help"
-complete -f -c wd -k -n "_wd_complete_empty" -a version -d "show version"
-complete -f -c wd -k -n "_wd_complete_empty" -a ls -d "ls warp point directory"
-complete -f -c wd -k -n "_wd_complete_empty" -a path -d "show path of warp point"
-complete -f -c wd -k -n "_wd_complete_empty" -a list -d "list warp points"
-complete -f -c wd -k -n "_wd_complete_empty" -a rm -d "remove warp point"
-complete -f -c wd -k -n "_wd_complete_empty" -a add -d "add warp point"
+complete -f -c wd -k -n _wd_complete_empty -a help -d "show help"
+complete -f -c wd -k -n _wd_complete_empty -a version -d "show version"
+complete -f -c wd -k -n _wd_complete_empty -a ls -d "ls warp point directory"
+complete -f -c wd -k -n _wd_complete_empty -a path -d "show path of warp point"
+complete -f -c wd -k -n _wd_complete_empty -a list -d "list warp points"
+complete -f -c wd -k -n _wd_complete_empty -a rm -d "remove warp point"
+complete -f -c wd -k -n _wd_complete_empty -a add -d "add warp point"
 
 # complete subdirs of given point
 complete -f -c wd -a "(_wd_complete_subdir)"
@@ -51,7 +51,7 @@ function _wd_complete_point
 
         # add with description, separated by tab
         set points "$points\n$split[1]\t -> $split[2..-1]"
-    end < $wd_rc
+    end <$wd_rc
 
     echo $points | string unescape
 end
@@ -68,5 +68,5 @@ function _wd_complete_subdir
             __fish_complete_directories "$path/$subpath" | string replace "$path/" ""
             return 0
         end
-    end < $wd_rc
+    end <$wd_rc
 end

--- a/functions/wd.fish
+++ b/functions/wd.fish
@@ -58,7 +58,7 @@ function _wd_add
     end
 
     # check for illegal chars
-    if string match '*:*' $point > /dev/null
+    if string match '*:*' $point >/dev/null
         echo "error: name contains illeagal characters" 1>&2
         return 1
     end
@@ -71,10 +71,10 @@ function _wd_add
             echo "error: point '$point' already exists" 1>&2
             return 1
         end
-    end < $wd_rc
+    end <$wd_rc
 
     # add warp point
-    echo "$point:$PWD" >> $wd_rc
+    echo "$point:$PWD" >>$wd_rc
 end
 
 function _wd_rm
@@ -100,13 +100,13 @@ function _wd_rm
         if contains $point $argv
             set -a found $point
         else
-            echo $line >> $tmp
+            echo $line >>$tmp
         end
-    end < $wd_rc
+    end <$wd_rc
 
     # if found, update rc
     if test (count $found) -gt 0
-        cat $tmp > $wd_rc
+        cat $tmp >$wd_rc
     end
 
     # warn about those not found
@@ -151,7 +151,7 @@ function _wd_warp -a point subdir
             cd "$path"
             return 0
         end
-    end < $wd_rc
+    end <$wd_rc
 
     # not found
     echo "error: warp point '$point' not found" 1>&2
@@ -164,7 +164,7 @@ function _wd_list
         set path (string replace "$HOME" "~" $split[2..-1])
 
         printf "$split[1]\t -> \t $path\n"
-    end < $wd_rc
+    end <$wd_rc
 end
 
 function _wd_ls -a point
@@ -182,7 +182,7 @@ function _wd_ls -a point
             ls "$split[2..-1]"
             return 0
         end
-    end < $wd_rc
+    end <$wd_rc
 
     # not found
     echo "error: point '$point' not found" 1>&2
@@ -204,7 +204,7 @@ function _wd_path -a point
             echo "$split[2..-1]"
             return 0
         end
-    end < $wd_rc
+    end <$wd_rc
 
     # not found
     echo "error: point '$point' not found" 1>&2


### PR DESCRIPTION
## Summary

- Fix existing `fish_indent` formatting violations in both `.fish` files
- Add GitHub Actions workflow that runs `fish --no-execute` (syntax) and `fish_indent --check` (formatting) on all `.fish` files for pushes to master and PRs

Uses [fish-shop](https://github.com/fish-shop) actions, all pinned to SHA hashes.

## Test plan

- [ ] CI passes on this PR itself (both files were pre-formatted)
- [ ] Future PRs with syntax errors or bad indentation are caught